### PR TITLE
Added opaque texture requirement to URP section

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ Install the package, add `OutlineFeature` to `ScriptableRendererData`'s list of 
 
 ![URP outline settings](Docs/UrpOutlineSettings.png "URP outline settings")
 
-Enable depth texture rendering in `UniversalRenderPipelineAsset` and that's it!
+Enable depth texture and opaque texture rendering in `UniversalRenderPipelineAsset` and that's it!
 
 ### Integration with High Definition Render Pipeline (HDRP).
 [![NPM](https://nodei.co/npm/com.unityfx.outline.hdrp.png)](https://www.npmjs.com/package/com.unityfx.outline.hdrp)


### PR DESCRIPTION
It took a while to realize I needed the opaque texture rendering feature enabled on URP. So this just adds that as a note.