### PR TITLE
Hide srp not support warning when urp toolkit for urp is installed.

### DIFF
--- a/Outline.Core/Packages/UnityFx.Outline/Runtime/Scripts/OutlineResources.cs
+++ b/Outline.Core/Packages/UnityFx.Outline/Runtime/Scripts/OutlineResources.cs
@@ -494,6 +494,16 @@ namespace UnityFx.Outline
 		{
 			if (GraphicsSettings.renderPipelineAsset)
 			{
+
+#if UNITY_EDITOR
+				// check whether package for urp installed or not.
+				string srpPackagePath = "Packages/com.unityfx.outline.urp/package/json";
+				string absolutePath = System.IO.Path.GetFullPath(path);
+
+				if (System.IO.File.Exist(absolutePath)) {
+					return;
+				}
+#endif
 				UnityEngine.Debug.LogWarningFormat(obj, SrpNotSupported, obj.GetType().Name);
 			}
 		}


### PR DESCRIPTION
added check routine for issue #37 .
I can't sure the warning was intended, however I thought it was just not considered.