### PR TITLE
Fix Depth Outlines for URP 13+

### DIFF
--- a/Outline.URP/Packages/UnityFx.Outline.URP/Runtime/Scripts/OutlinePass.cs
+++ b/Outline.URP/Packages/UnityFx.Outline.URP/Runtime/Scripts/OutlinePass.cs
@@ -56,6 +56,7 @@ namespace UnityFx.Outline.URP
 			var camData = renderingData.cameraData;
 
 #if UNITY_2022_1_OR_NEWER
+			// URP 13 (Unity 2022.1+) has non-documented breaking changes related to _CameraDepthTexture. Reflection is used here to retrieve _CameraDepthTexture's underlying depth texture, as suggested by the "How to set _CameraDepthTexture as render target in URP 13?" forum, see https://forum.unity.com/threads/how-to-set-_cameradepthtexture-as-render-target-in-urp-13.1279934/#post-8272821
             var depthTextureHandle = depthTextureFieldInfo.GetValue(camData.renderer) as RTHandle;
 #else
 			var depthTexture = new RenderTargetIdentifier("_CameraDepthTexture");

--- a/Outline.URP/Packages/UnityFx.Outline.URP/Runtime/Scripts/OutlinePass.cs
+++ b/Outline.URP/Packages/UnityFx.Outline.URP/Runtime/Scripts/OutlinePass.cs
@@ -1,8 +1,9 @@
-﻿// Copyright (C) 2019-2021 Alexander Bogarsukov. All rights reserved.
+// Copyright (C) 2019-2021 Alexander Bogarsukov. All rights reserved.
 // See the LICENSE.md file in the project root for more information.
 
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 using UnityEngine;
 using UnityEngine.Rendering;
 using UnityEngine.Rendering.Universal;
@@ -20,7 +21,11 @@ namespace UnityFx.Outline.URP
 
 		private ScriptableRenderer _renderer;
 
-		public OutlinePass(OutlineFeature feature, string[] shaderTags)
+#if UNITY_2022_1_OR_NEWER
+        private readonly static FieldInfo depthTextureFieldInfo = typeof(UniversalRenderer).GetField("m_DepthTexture", BindingFlags.NonPublic | BindingFlags.Instance);
+#endif
+
+        public OutlinePass(OutlineFeature feature, string[] shaderTags)
 		{
 			_feature = feature;
 
@@ -44,14 +49,19 @@ namespace UnityFx.Outline.URP
 			_renderer = renderer;
 		}
 
-		public override void Execute(ScriptableRenderContext context, ref RenderingData renderingData)
+        public override void Execute(ScriptableRenderContext context, ref RenderingData renderingData)
 		{
 			var outlineResources = _feature.OutlineResources;
 			var outlineSettings = _feature.OutlineSettings;
 			var camData = renderingData.cameraData;
-			var depthTexture = new RenderTargetIdentifier("_CameraDepthTexture");
 
-			if (_feature.OutlineLayerMask != 0)
+#if UNITY_2022_1_OR_NEWER
+            var depthTextureHandle = depthTextureFieldInfo.GetValue(camData.renderer) as RTHandle;
+#else
+			var depthTexture = new RenderTargetIdentifier("_CameraDepthTexture");
+#endif
+
+            if (_feature.OutlineLayerMask != 0)
 			{
 				var cmd = CommandBufferPool.Get(_feature.FeatureName);
 				var filteringSettings = new FilteringSettings(RenderQueueRange.all, _feature.OutlineLayerMask, _feature.OutlineRenderingLayerMask);
@@ -72,9 +82,13 @@ namespace UnityFx.Outline.URP
 					drawingSettings.overrideMaterialPassIndex = OutlineResources.RenderShaderDefaultPassId;
 				}
 
-				using (var renderer = new OutlineRenderer(cmd, outlineResources, _renderer.cameraColorTarget, depthTexture, camData.cameraTargetDescriptor))
-				{
-					renderer.RenderObjectClear(outlineSettings.OutlineRenderMode);
+#if UNITY_2022_1_OR_NEWER
+                using (var renderer = new OutlineRenderer(cmd, outlineResources, _renderer.cameraColorTargetHandle, depthTextureHandle, camData.cameraTargetDescriptor))
+#else
+                using (var renderer = new OutlineRenderer(cmd, outlineResources, _renderer.cameraColorTarget, depthTexture, camData.cameraTargetDescriptor))
+#endif
+                {
+                    renderer.RenderObjectClear(outlineSettings.OutlineRenderMode);
 					context.ExecuteCommandBuffer(cmd);
 
 					context.DrawRenderers(renderingData.cullResults, ref drawingSettings, ref filteringSettings, ref renderStateBlock);
@@ -91,9 +105,13 @@ namespace UnityFx.Outline.URP
 			{
 				var cmd = CommandBufferPool.Get(OutlineResources.EffectName);
 
+#if UNITY_2022_1_OR_NEWER
+				using (var renderer = new OutlineRenderer(cmd, outlineResources, _renderer.cameraColorTargetHandle, depthTextureHandle, camData.cameraTargetDescriptor))
+#else
 				using (var renderer = new OutlineRenderer(cmd, outlineResources, _renderer.cameraColorTarget, depthTexture, camData.cameraTargetDescriptor))
-				{
-					_renderObjects.Clear();
+#endif
+                {
+                    _renderObjects.Clear();
 					_feature.OutlineLayers.GetRenderObjects(_renderObjects);
 					renderer.Render(_renderObjects);
 				}


### PR DESCRIPTION
Fixes #60

Outlines would trigger a CommandBuffer warning (full error below) when "Enable Depth Testing" was enabled, turning the screen black.

For whatever reason, `new RenderTargetIdentifier("_CameraDepthTexture")` don't work no mo and Unity decided to provide no solid alternative (you could use camData.renderer.cameraDepthTargetHandle but it suffers from incompatibility with MSAA). THE ONLY FIX I could find was hidden in [some desolate forum](https://forum.unity.com/threads/how-to-set-_cameradepthtexture-as-render-target-in-urp-13.1279934/#post-8272821) using Reflection, thank god for the community.

Despite my attitude I'm really happy with this fix: this is the best Outline package out there (...right?) and I would hate for it to get abandoned because of Unity pullin' a fast one on us.

```
CommandBuffer: temporary render texture _CameraDepthTexture not found while executing Outline--1 (SetRenderTarget depth buffer)
UnityEngine.GUIUtility:ProcessEvent (int,intptr,bool&)
```

_sidenote: the diff is larger than it should be, probably because I updated line endings. Oh well 🤷_