### PR TITLE
Update package.json

### DIFF
--- a/Outline.HDRP/Packages/UnityFx.Outline.HDRP/package.json
+++ b/Outline.HDRP/Packages/UnityFx.Outline.HDRP/package.json
@@ -1,11 +1,11 @@
 {
     "name": "com.unityfx.outline.hdrp",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "displayName": "Screen-space outline (HDRP)",
     "description": "Configurable outline for HDRP.",
     "unity": "2019.3",
     "dependencies": {
-        "com.unityfx.outline": "0.8.0",
+        "com.unityfx.outline": "0.8.5",
         "com.unity.render-pipelines.high-definition": "7.0.0"
     },
     "keywords": [


### PR DESCRIPTION
Prompt openupm for update.

Currently, installing via OpenUPM causes a compile error.