### PR TITLE
Update URP OutlineColor shader to remove bug

### DIFF
--- a/Outline.URP/Packages/UnityFx.Outline.URP/Runtime/Shaders/OutlineColor.URP.shader
+++ b/Outline.URP/Packages/UnityFx.Outline.URP/Runtime/Shaders/OutlineColor.URP.shader
@@ -22,8 +22,8 @@ Shader "Hidden/UnityFx/OutlineColor.URP"
 
 		half4 FragmentAlphaTest(Varyings input) : SV_Target
 		{
-			half4 c = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, input.uv);
-			clip(c.a - _Cutoff);
+			//half4 c = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, input.uv);
+			//clip(c.a - _Cutoff);
 			return 1;
 		}
 
@@ -59,7 +59,7 @@ Shader "Hidden/UnityFx/OutlineColor.URP"
 
 			#pragma multi_compile_instancing
 			#pragma vertex Vert
-			#pragma fragment FragmentAlphaTest
+			// #pragma fragment FragmentAlphaTest
 
 			ENDHLSL
 		}


### PR DESCRIPTION
Upon building, multiple people get the error "invalid subscript 'uv' at line 26 (on d3d11)". 

Please see this [Unity Forum thread](https://forum.unity.com/threads/shader-object-only-works-with-invalid-subscript-error-post-processing-urp-shader.1383438/)

I don't think the code is doing anything other than creating an error. This is my first PR so apologies if I'm terribly wrong about this.